### PR TITLE
update parse-tag to include attributes with colons

### DIFF
--- a/lib/parse-tag.js
+++ b/lib/parse-tag.js
@@ -1,4 +1,4 @@
-var attrRE = /([\w-]+)|['"]{1}([^'"]*)['"]{1}/g;
+var attrRE = /([\w:-]+)|['"]{1}([^'"]*)['"]{1}/g;
 
 // create optimized lookup object for
 // void elements as listed here: 

--- a/test/parse-tag.js
+++ b/test/parse-tag.js
@@ -53,5 +53,21 @@ test('parseTag', function (t) {
         children: []
     });
 
+    tag = '<svg aria-hidden="true" style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" data-id="175">'
+    t.deepEqual(parseTag(tag), {
+        type: 'tag', 
+        name: 'svg', 
+        attrs: { 
+            'aria-hidden': 'true', 
+            'data-id': '175', 
+            style: 'position: absolute; width: 0; height: 0; overflow: hidden;', 
+            version: '1.1', 
+            xmlns: 'http://www.w3.org/2000/svg', 
+            'xmlns:xlink': 'http://www.w3.org/1999/xlink' 
+        },
+        voidElement: false,
+        children: []
+    }, 'should parse attributes with hyphens and colons');
+
     t.end();
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -366,6 +366,7 @@ test('parse', function (t) {
             { type: 'text', content: 'There' }
         ]
     }], 'should remove text nodes that are nothing but whitespace');
+
     t.end();
 });
 


### PR DESCRIPTION
Modified the parse-tag regex slightly to include attributes with colons, for example `xmlns:xlink` and added tests for similar attributes and spinal-case attributes